### PR TITLE
Update devcontainer build

### DIFF
--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -32,7 +32,7 @@ jobs:
             echo "tag=latest" >> $GITHUB_OUTPUT
           else
             # Sanitize branch name: replace / and other non-alphanum with -
-            sanitized=$(echo "${GITHUB_REF##*/}" | tr '/[^a-zA-Z0-9_-]' '-')
+            sanitized=$(echo "${GITHUB_REF##*/}" | tr -c 'a-zA-Z0-9_' '-')
             echo "tag=${sanitized}" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -36,10 +36,12 @@ jobs:
         run: |
           if [ "${GITHUB_REF##*/}" = "main" ]; then
             echo "tag=latest" >> $GITHUB_OUTPUT
+            echo Setting tag to latest
           else
             # Sanitize branch name: replace / and other non-alphanum with -
-            sanitized=$(echo "${GITHUB_REF##*/}" | tr -c 'a-zA-Z0-9_' '-')
+            sanitized=$(echo "${GITHUB_REF##*/}" | tr -c 'a-zA-Z0-9_' '-' | sed 's/^-*//;s/-*$//')
             echo "tag=${sanitized}" >> $GITHUB_OUTPUT
+            echo Setting tag to ${sanitized}
           fi
 
       - name: Pre-build dev container image

--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2 
         with:

--- a/.github/workflows/build_devcontainer.yaml
+++ b/.github/workflows/build_devcontainer.yaml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - '.devcontainer/**'
+  schedule:
+    - cron: '0 0 1 * *'
 jobs:
   build-devcontainer:
     runs-on: ubuntu-latest
@@ -23,6 +25,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR }}
 
+      - name: Set image tag
+        id: set_tag
+        run: |
+          if [ "${GITHUB_REF##*/}" = "main" ]; then
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          else
+            # Sanitize branch name: replace / and other non-alphanum with -
+            sanitized=$(echo "${GITHUB_REF##*/}" | tr '/[^a-zA-Z0-9_-]' '-')
+            echo "tag=${sanitized}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Pre-build dev container image
         uses: devcontainers/ci@v0.3
         with:
@@ -30,3 +43,5 @@ jobs:
           cacheFrom: ghcr.io/karstenb/hermitgrab-devcontainer
           push: always
           configFile: .devcontainer/build/devcontainer.json
+          platform: linux/amd64,linux/arm64
+          imageTag: ${{ steps.set_tag.outputs.tag }}


### PR DESCRIPTION
Generate multi-arch images (AMD64 and ARM64) and use tags other than latest for non-main builds.
Also re-build the image once a month.